### PR TITLE
Add inline bundle verification

### DIFF
--- a/pkg/bnd/verifier.go
+++ b/pkg/bnd/verifier.go
@@ -52,7 +52,7 @@ func (v *Verifier) VerifyInlineBundle(bundleContents []byte) (*verify.Verificati
 
 	err := bndl.UnmarshalJSON(bundleContents)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshaling JSON: %w", err)
 	}
 
 	vrfr, err := v.bundleVerifier.BuildSigstoreVerifier(&v.Options)

--- a/pkg/bnd/verifier.go
+++ b/pkg/bnd/verifier.go
@@ -6,6 +6,8 @@ package bnd
 import (
 	"fmt"
 
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
 
@@ -26,18 +28,41 @@ type Verifier struct {
 }
 
 // VerifyBundle verifies a signed bundle containing a dsse envelope
-func (v *Verifier) VerifyBundle(budlePath string) (*verify.VerificationResult, error) {
-	bndl, err := v.bundleVerifier.OpenBundle(budlePath)
+func (v *Verifier) VerifyBundle(bundlePath string) (*verify.VerificationResult, error) {
+	bndl, err := v.bundleVerifier.OpenBundle(bundlePath)
 	if err != nil {
 		return nil, fmt.Errorf("opening bundle: %w", err)
 	}
 
 	vrfr, err := v.bundleVerifier.BuildSigstoreVerifier(&v.Options)
 	if err != nil {
-		return nil, fmt.Errorf("creatging creating verifier: %w", err)
+		return nil, fmt.Errorf("creating verifier: %w", err)
 	}
 
 	result, err := v.bundleVerifier.RunVerification(&v.Options, vrfr, bndl)
+	if err != nil {
+		return nil, fmt.Errorf("verifying bundle: %w", err)
+	}
+
+	return result, err
+}
+
+// VerifyBundle verifies a signed bundle containing a dsse envelope
+func (v *Verifier) VerifyInlineBundle(bundleContents []byte) (*verify.VerificationResult, error) {
+	var bndl bundle.Bundle
+	bndl.Bundle = new(protobundle.Bundle)
+
+	err := bndl.UnmarshalJSON(bundleContents)
+	if err != nil {
+		return nil, err
+	}
+
+	vrfr, err := v.bundleVerifier.BuildSigstoreVerifier(&v.Options)
+	if err != nil {
+		return nil, fmt.Errorf("creating verifier: %w", err)
+	}
+
+	result, err := v.bundleVerifier.RunVerification(&v.Options, vrfr, &bndl)
 	if err != nil {
 		return nil, fmt.Errorf("verifying bundle: %w", err)
 	}

--- a/pkg/bnd/verifier.go
+++ b/pkg/bnd/verifier.go
@@ -6,7 +6,6 @@ package bnd
 import (
 	"fmt"
 
-	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
@@ -50,7 +49,6 @@ func (v *Verifier) VerifyBundle(bundlePath string) (*verify.VerificationResult, 
 // VerifyBundle verifies a signed bundle containing a dsse envelope
 func (v *Verifier) VerifyInlineBundle(bundleContents []byte) (*verify.VerificationResult, error) {
 	var bndl bundle.Bundle
-	bndl.Bundle = new(protobundle.Bundle)
 
 	err := bndl.UnmarshalJSON(bundleContents)
 	if err != nil {


### PR DESCRIPTION
Previously the only way to verify a bundle was if the bundle was in a file on disk.

This changes adds 'inline' verification where the bundle JSON can be provided and verified without needing to read from disk.

Also fixes some minor typos elsewhere.