### PR TITLE
Add read subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/carabiner-dev/bnd
 go 1.24.3
 
 require (
-	github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193
+	github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250625055119-2ae04903ae66
 	github.com/carabiner-dev/github v0.2.2
 	github.com/carabiner-dev/hasher v0.2.2
 	github.com/carabiner-dev/jsonl v0.2.0
 	github.com/go-git/go-git/v5 v5.16.2
+	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/in-toto/attestation v1.1.2
 	github.com/sigstore/protobuf-specs v0.4.3
 	github.com/sigstore/sigstore v1.9.5
@@ -30,9 +31,10 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/carabiner-dev/ghrfs v0.3.2 // indirect
 	github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd // indirect
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 // indirect
-	github.com/carabiner-dev/vcslocator v0.2.2 // indirect
+	github.com/carabiner-dev/vcslocator v0.3.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
@@ -47,7 +49,6 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,12 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193 h1:wD6nGN7gq5IQJ4qFF0V4Jpu8B2FM+9ZnwlUqN5scWxk=
-github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250521004715-85b637ea9193/go.mod h1:sQEeCRjbikSoqB1+VmZmWK2R0u2NdauEXDab+VlS8pQ=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250624131420-719f43cc24dd h1:NSd0Y5uoPtpCCDyhmTuiAmdDwdx8pq6Q8nzzhmoxr7c=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250624131420-719f43cc24dd/go.mod h1:ukILmafFM9No+4C5pM89sUs+7RFtB1We9DB9+OvItEM=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250625055119-2ae04903ae66 h1:90vTDpwtvAhjdLGFkO5x4ARBwINJ+a2cop/CGkK1wF4=
+github.com/carabiner-dev/ampel v0.0.1-pre9.0.20250625055119-2ae04903ae66/go.mod h1:ukILmafFM9No+4C5pM89sUs+7RFtB1We9DB9+OvItEM=
+github.com/carabiner-dev/ghrfs v0.3.2 h1:SBxmC7H2efJzebzrpZNsXB/03eZTeBORguXvKftpif4=
+github.com/carabiner-dev/ghrfs v0.3.2/go.mod h1:xRewpmbdE766e+XlKfcH+p/KcObAflOIwNq6s7TARb0=
 github.com/carabiner-dev/github v0.2.2 h1:Ykrlcct71fRQm4j37LhAz9FyzG4n1nlm2e+V62MIoJM=
 github.com/carabiner-dev/github v0.2.2/go.mod h1:J7VqMAUewwRQH6r6HMDmVNf39f/z7H5iyTzOfC8am9A=
 github.com/carabiner-dev/hasher v0.2.2 h1:wYzqB/BeiK7/D+Ho1VofcjrzvnlAalre0AeFOB3KmxM=
@@ -97,8 +101,8 @@ github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd h1:WEQbh3d2h
 github.com/carabiner-dev/openeox v0.0.0-20250430212020-e3a5beb42ddd/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/vcslocator v0.2.2 h1:UXhuMUxtDiwGzfCxvpNJXRyqUY8qZl0+Ug3TjJluS4s=
-github.com/carabiner-dev/vcslocator v0.2.2/go.mod h1:/67gubbzxtg25MIg/eRlmBkHExFDqyVZ2Dj0VJatHwE=
+github.com/carabiner-dev/vcslocator v0.3.1 h1:TIC7NfrBjMUkul9F+vvrDVIxxRqhsywjWy4L7WzdaMA=
+github.com/carabiner-dev/vcslocator v0.3.1/go.mod h1:jvYlXLVyqQqkBuSH/CiE1pbHifoPaAhWtUjLquHaBb0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=

--- a/internal/cmd/inspect.go
+++ b/internal/cmd/inspect.go
@@ -74,7 +74,10 @@ data about the bundle.
 			fmt.Println("\n🔎  Bundle Details:")
 			fmt.Println("-------------------")
 
-			renderer := render.New()
+			renderer, err := render.New()
+			if err != nil {
+				return err
+			}
 			if strings.HasSuffix(opts.Path, ".jsonl") {
 				for i, r := range jsonl.IterateBundle(reader) {
 					if r == nil {

--- a/internal/cmd/inspect.go
+++ b/internal/cmd/inspect.go
@@ -7,14 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/carabiner-dev/ampel/pkg/attestation"
-	ampelb "github.com/carabiner-dev/ampel/pkg/formats/envelope/bundle"
 	"github.com/carabiner-dev/jsonl"
 	"github.com/spf13/cobra"
 
 	"github.com/carabiner-dev/bnd/pkg/bundle"
+	"github.com/carabiner-dev/bnd/pkg/render"
 )
 
 type inspectOptions struct {
@@ -73,6 +74,7 @@ data about the bundle.
 			fmt.Println("\n🔎  Bundle Details:")
 			fmt.Println("-------------------")
 
+			renderer := render.New()
 			if strings.HasSuffix(opts.Path, ".jsonl") {
 				for i, r := range jsonl.IterateBundle(reader) {
 					if r == nil {
@@ -80,7 +82,7 @@ data about the bundle.
 						continue
 					}
 					fmt.Printf("Attestation #%d\n", i)
-					if err := printEnvelopeDetails(r); err != nil {
+					if err := printEnvelopeDetails(renderer, r); err != nil {
 						return err
 					}
 				}
@@ -88,14 +90,14 @@ data about the bundle.
 			}
 
 			// If it's just a single json:
-			return printEnvelopeDetails(reader)
+			return printEnvelopeDetails(renderer, reader)
 		},
 	}
 	opts.AddFlags(extractCmd)
 	parentCmd.AddCommand(extractCmd)
 }
 
-func printEnvelopeDetails(reader io.Reader) error {
+func printEnvelopeDetails(renderer *render.Renderer, reader io.Reader) error {
 	tool := bundle.NewTool()
 
 	// Parse the bundle JSON
@@ -107,71 +109,5 @@ func printEnvelopeDetails(reader io.Reader) error {
 		}
 		return fmt.Errorf("parsing bundle: %w", err)
 	}
-
-	verifyErr := envelope.Verify()
-
-	att, err := tool.ExtractAttestation(envelope)
-	if err != nil {
-		return fmt.Errorf("unable to extract attestation from bundle")
-	}
-
-	mediatype := "unknown"
-	if bndl, ok := envelope.(*ampelb.Envelope); ok {
-		mediatype = bndl.GetMediaType()
-	}
-
-	fmt.Printf("✉️  Envelope Media Type: %s\n", mediatype)
-	idstr := "[✗ not signed]\n"
-	if verifyErr != nil {
-		idstr = fmt.Sprintf("[error: %s]", err)
-	}
-	if att.GetVerification() != nil {
-		idstr = "[No identity found]\n"
-		if att.GetVerification().GetSignature().GetIdentities() != nil {
-			idstr = ""
-			for i, id := range att.GetVerification().GetSignature().GetIdentities() {
-				if i > 0 {
-					idstr += strings.Repeat(" ", 19)
-				}
-				idstr += id.Slug() + "\n"
-			}
-		}
-	}
-	fmt.Printf("🔏 Signer identity: %s", idstr)
-	if att != nil {
-		fmt.Println("📃 Attestation Details:")
-		fmt.Printf("   Predicate Type: %s", att.GetPredicateType())
-		if att.GetPredicateType() == "" {
-			fmt.Print("[not defined]")
-		}
-		fmt.Println("")
-
-		if att.GetSubjects() != nil {
-			fmt.Printf("   Attestation Subjects:\n")
-			for _, s := range att.GetSubjects() {
-				if s.GetName() != "" {
-					fmt.Println("   - " + s.GetName())
-				}
-
-				i := 0
-				for algo, val := range s.GetDigest() {
-					if i == 0 {
-						if s.GetName() == "" {
-							fmt.Print("   - ")
-						} else {
-							fmt.Print("     ")
-						}
-						fmt.Printf("%s: %s\n", algo, val)
-					}
-					i++
-				}
-			}
-		} else {
-			fmt.Println("⚠️ Attestation has no subjects")
-		}
-	} else {
-		fmt.Println("⚠️ No attestation found in envelope")
-	}
-	fmt.Println("")
-	return nil
+	return renderer.DisplayEnvelopeDetails(os.Stdout, envelope)
 }

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/carabiner-dev/bnd/pkg/reader"
+	"github.com/carabiner-dev/bnd/pkg/render"
+)
+
+type readOptions struct {
+	sigstoreOptions
+	BackendUri       string
+	VerifySignatures bool
+	DumpRaw          bool
+}
+
+// Validate checks the options
+func (ro *readOptions) Validate() error {
+	errs := []error{}
+	errs = append(errs,
+		ro.sigstoreOptions.Validate(),
+	)
+
+	if ro.BackendUri == "" {
+		errs = append(errs, errors.New("missing source repository URI"))
+	}
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the subcommands flags
+func (ro *readOptions) AddFlags(cmd *cobra.Command) {
+	ro.sigstoreOptions.AddFlags(cmd)
+
+	cmd.PersistentFlags().StringVar(
+		&ro.BackendUri, "uri", "", "source repository URI to read attestations",
+	)
+
+	cmd.PersistentFlags().BoolVarP(
+		&ro.VerifySignatures, "verify", "v", true, "verify the attestation signatures",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&ro.DumpRaw, "raw", false, "dump the attestations in raw JSON",
+	)
+}
+
+func addRead(parentCmd *cobra.Command) {
+	opts := &readOptions{}
+	readCmd := &cobra.Command{
+		Short: "read attestations from source repositories",
+		Long: fmt.Sprintf(`
+🥨 %s read
+The read subcommands lists attestations from a source repository. 
+
+By using the read subcommand, bnd can retrieve attestations from different
+repositories. Under the hood, this subcommand uses AMPEL's attestation
+collector and its default drivers. Here are some use examples using different
+repository drivers:
+
+Read from a linear JSON file (jsonl):
+
+> bnd read jsonl:attestations.jsonl
+
+Read attestations from a git commit note:
+
+> bnd read note:slsa-framework/slsa-source-poc@82d60d3569844fa1d060000909c6b62e3d3fd947 
+
+Read from a GitHub release:
+
+> bnd read release:github.com/example/repo@v1.0.1
+
+Read from the GitHub attestations store:
+
+> bnd read github:owner/repo
+
+Read attestations from a directory:
+
+> bnd read fs:/home/files/attestations/
+
+
+`, appname),
+		Use:               "read",
+		Example:           fmt.Sprintf(`%s read source`, appname),
+		SilenceUsage:      false,
+		SilenceErrors:     true,
+		PersistentPreRunE: initLogging,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.BackendUri = args[0]
+			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, args []string) error {
+			client := reader.New()
+			atts, err := client.Fetch(opts.BackendUri)
+			if err != nil {
+				return err
+			}
+
+			renderer, err := render.New(render.WithVerifySignatures(opts.VerifySignatures))
+			if err != nil {
+				return err
+			}
+			for _, a := range atts {
+				if opts.DumpRaw {
+					fmt.Println(string(a.GetPredicate().GetData()))
+					continue
+				}
+				if err := renderer.DisplayEnvelopeDetails(os.Stdout, a); err != nil {
+					return fmt.Errorf("rendering attestation: %w", err)
+				}
+			}
+			return nil
+		},
+	}
+	opts.AddFlags(readCmd)
+	parentCmd.AddCommand(readCmd)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -76,6 +76,7 @@ func Execute() {
 	addPack(rootCmd)
 	addUnpack(rootCmd)
 	addCommit(rootCmd)
+	addRead(rootCmd)
 	rootCmd.AddCommand(version.WithFont("doom"))
 
 	if err := rootCmd.Execute(); err != nil {

--- a/pkg/reader/client.go
+++ b/pkg/reader/client.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package reader
+
+import (
+	"github.com/carabiner-dev/ampel/pkg/attestation"
+	"github.com/carabiner-dev/ampel/pkg/collector"
+)
+
+type Client struct {
+	impl clientImplementation
+}
+
+func New() *Client {
+	return &Client{
+		impl: &defaultClientImplementation{},
+	}
+}
+
+func buildAgent() (*collector.Agent, error) {
+	if err := collector.LoadDefaultRepositoryTypes(); err != nil {
+		return nil, err
+	}
+	return collector.New()
+}
+
+// Fetch retrieves all the attestation from a source repository
+func (c *Client) Fetch(uri string) ([]attestation.Envelope, error) {
+	return c.impl.Fetch(uri)
+}

--- a/pkg/reader/implementation.go
+++ b/pkg/reader/implementation.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package reader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/carabiner-dev/ampel/pkg/attestation"
+)
+
+type clientImplementation interface {
+	Fetch(string) ([]attestation.Envelope, error)
+}
+
+type defaultClientImplementation struct{}
+
+func (impl *defaultClientImplementation) Fetch(uri string) ([]attestation.Envelope, error) {
+	agent, err := buildAgent()
+	if err != nil {
+		return nil, fmt.Errorf("creating new collector agent: %w", err)
+	}
+	if err := agent.AddRepositoryFromString(uri); err != nil {
+		return nil, fmt.Errorf("adding new repository: %w", err)
+	}
+
+	return agent.Fetch(context.Background())
+}

--- a/pkg/render/options.go
+++ b/pkg/render/options.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+type Options struct {
+	VerifySignatures bool
+}
+
+var defaultOptions = Options{
+	VerifySignatures: true,
+}
+
+type FnOpt func(opts *Options) error
+
+func WithVerifySignatures(sino bool) FnOpt {
+	return func(opts *Options) error {
+		opts.VerifySignatures = sino
+		return nil
+	}
+}

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/carabiner-dev/ampel/pkg/attestation"
+	ampelb "github.com/carabiner-dev/ampel/pkg/formats/envelope/bundle"
+
+	"github.com/carabiner-dev/bnd/pkg/bundle"
+)
+
+func New() *Renderer {
+	return &Renderer{}
+}
+
+type Renderer struct{}
+
+// DisplayEnvelopeDetails prints the details of an attestation
+func (*Renderer) DisplayEnvelopeDetails(w io.Writer, envelope attestation.Envelope) error {
+	tool := bundle.NewTool()
+	verifyErr := envelope.Verify()
+
+	att, err := tool.ExtractAttestation(envelope)
+	if err != nil {
+		return fmt.Errorf("unable to extract attestation from bundle")
+	}
+
+	mediatype := "unknown"
+	if bndl, ok := envelope.(*ampelb.Envelope); ok {
+		mediatype = bndl.GetMediaType()
+	}
+
+	fmt.Printf("✉️  Envelope Media Type: %s\n", mediatype)
+	idstr := "[✗ not signed]\n"
+	if verifyErr != nil {
+		idstr = fmt.Sprintf("[error: %s]\n", verifyErr)
+	}
+	if att.GetVerification() != nil {
+		idstr = "[No identity found]\n"
+		if att.GetVerification().GetSignature().GetIdentities() != nil {
+			idstr = ""
+			for i, id := range att.GetVerification().GetSignature().GetIdentities() {
+				if i > 0 {
+					idstr += strings.Repeat(" ", 19)
+				}
+				idstr += id.Slug() + "\n"
+			}
+		}
+	}
+	fmt.Printf("🔏 Signer identity: %s", idstr)
+	if att != nil {
+		fmt.Println("📃 Attestation Details:")
+		fmt.Printf("   Predicate Type: %s", att.GetPredicateType())
+		if att.GetPredicateType() == "" {
+			fmt.Print("[not defined]")
+		}
+		fmt.Println("")
+
+		if att.GetSubjects() != nil {
+			fmt.Printf("   Attestation Subjects:\n")
+			for _, s := range att.GetSubjects() {
+				if s.GetName() != "" {
+					fmt.Println("   - " + s.GetName())
+				}
+
+				i := 0
+				for algo, val := range s.GetDigest() {
+					if i == 0 {
+						if s.GetName() == "" {
+							fmt.Print("   - ")
+						} else {
+							fmt.Print("     ")
+						}
+						fmt.Printf("%s: %s\n", algo, val)
+					}
+					i++
+				}
+			}
+		} else {
+			fmt.Println("⚠️ Attestation has no subjects")
+		}
+	} else {
+		fmt.Println("⚠️ No attestation found in envelope")
+	}
+	fmt.Println("")
+	return nil
+}


### PR DESCRIPTION
This PR adds a new read subcommand that uses ampel's collectors to read attestations from the supported source repositories.