### PR TITLE
Switch ls table to termtable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/jsonl v0.2.1
 	github.com/carabiner-dev/signer v0.4.5
+	github.com/carabiner-dev/termtable v1.1.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/in-toto/attestation v1.2.0
 	github.com/sigstore/protobuf-specs v0.5.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/term v0.42.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/release-sdk v0.12.6
@@ -123,6 +123,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/protobom/protobom v0.5.4 // indirect
 	github.com/regclient/regclient v0.11.3 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
@@ -154,6 +155,7 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTur
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
 github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
 github.com/carabiner-dev/signer v0.4.5/go.mod h1:B/53ToJAIgwM+KuDwj52+HwnlA5p8Rmz2OXQdy9x+xs=
+github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
+github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.3-0.20260415221723-1e7d86696551 h1:nclmBw4ane2OjB4bJQ0cTNFYx434QMakz3jHRbhCiJw=
 github.com/carabiner-dev/vcslocator v0.4.3-0.20260415221723-1e7d86696551/go.mod h1:ERs4j/p7YF+BWbIWHZdODOoUX5N1zhUkvjAB0kZ3nCQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -393,6 +395,8 @@ github.com/protobom/protobom v0.5.4 h1:fMSO3wA5BEj/J6f1zgT56Ps/6pcE0NGZZzphnIoL/
 github.com/protobom/protobom v0.5.4/go.mod h1:zz85kBItD/hO6c9o18pFXgFv2UOwtAhqZDAITIfPJcs=
 github.com/regclient/regclient v0.11.3 h1:aTnVRsgFaOmezgKp7caL3zINrZKAXsMbzS1oCgD7/cA=
 github.com/regclient/regclient v0.11.3/go.mod h1:a4PDi+VyEbBuV/5hCfMjnYH8jvB7NgD0mdggwNRECy8=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/cmd/ls.go
+++ b/internal/cmd/ls.go
@@ -17,8 +17,8 @@ import (
 	"github.com/carabiner-dev/command/keys"
 	signer "github.com/carabiner-dev/signer/api/v1"
 	"github.com/carabiner-dev/signer/key"
+	"github.com/carabiner-dev/termtable"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/carabiner-dev/bnd/internal/supplychain"
 	"github.com/carabiner-dev/bnd/pkg/bundle"
@@ -29,9 +29,6 @@ const (
 	lsHeaderPredicateType = "PREDICATE TYPE"
 	lsHeaderSignerID      = "SIGNER IDENTITY"
 	lsHeaderSubject       = "SUBJECT"
-	lsColumnGap           = 3
-	lsNumColumns          = 3
-	lsDefaultWidth        = 80
 )
 
 type lsOptions struct {
@@ -333,89 +330,120 @@ func extractSubjectSlugs(att attestation.Statement) []string {
 	return slugs
 }
 
-// terminalWidth returns the width of the terminal or a default value.
-func terminalWidth() int {
-	fd := os.Stdout.Fd()
-	w, _, err := term.GetSize(int(fd)) //nolint:gosec // fd is always a valid small descriptor
-	if err != nil || w <= 0 {
-		return lsDefaultWidth
+// lsBorderSet returns the border glyph set used by every ls table.
+// Horizontal runs render as ASCII '-' so the rule under the header
+// looks like the pre-termtable version. Verticals and junctions are
+// spaces — never drawn because the table has `border: none` and only
+// the header row opts back in via `border-bottom: solid`.
+func lsBorderSet() termtable.BorderSet {
+	b := termtable.BorderSet{
+		Horizontal: '-',
+		Vertical:   ' ',
 	}
-	return w
+	for i := range b.Joins {
+		b.Joins[i] = ' '
+	}
+	return b
 }
 
-// printLsTable renders the three-column table to w. Each column is
-// exactly 1/3 of the terminal width (minus inter-column gaps).
+// newLsTable builds a borderless termtable with the ls conventions
+// applied: dash horizontal rule glyphs, 1-column padding on each
+// side of content, no default borders anywhere, and the layout
+// pinned to 100 % of the terminal width (overriding termtable's
+// default 90 % ceiling).
+func newLsTable() *termtable.Table {
+	return termtable.NewTable(
+		termtable.WithBorder(lsBorderSet()),
+		termtable.WithTargetWidthPercent(100),
+		termtable.WithTableStyle("border: none"),
+	)
+}
+
+// addLsHeader appends the column-header row with an underline. Cells
+// are passed as CellOption slices so callers can supply the uppercased
+// column titles in one place.
+func addLsHeader(t *termtable.Table, titles ...string) {
+	hdr := t.AddHeader(termtable.WithRowBorderBottom(termtable.BorderEdgeSolid))
+	for _, title := range titles {
+		hdr.AddCell(termtable.WithContent(title))
+	}
+}
+
+// equalColumnWidths pins every column to an equal share of the
+// table target — the bnd "fixed thirds" look applied via termtable's
+// percent-width support. Pass n = table.NumColumns() (or the column
+// count you'll populate before writing).
+func equalColumnWidths(t *termtable.Table, n int) {
+	if n < 1 {
+		return
+	}
+	pct := 100 / n
+	for i := range n {
+		t.Column(i).Style(fmt.Sprintf("white-space: nowrap; text-overflow: ellipsis; width: %d%%", pct))
+	}
+}
+
+// printLsTable renders the three-column table to w.
 func printLsTable(w io.Writer, rows []lsRow) {
-	totalWidth := terminalWidth()
-	colWidth := columnWidth(totalWidth)
+	t := newLsTable()
+	equalColumnWidths(t, 3)
+	addLsHeader(t, lsHeaderPredicateType, lsHeaderSignerID, lsHeaderSubject)
 
-	printRow := func(a, b, c string) {
-		fmt.Fprintf(w, "%-*s%-*s%s\n", colWidth+lsColumnGap, a, colWidth+lsColumnGap, b, c) //nolint:errcheck // writing to terminal
-	}
-
-	// Print header
-	printRow(lsHeaderPredicateType, lsHeaderSignerID, lsHeaderSubject)
-	printRow(strings.Repeat("-", colWidth), strings.Repeat("-", colWidth), strings.Repeat("-", colWidth))
-
-	// Print rows
+	budget := identityBudget(t, 3)
 	for _, r := range rows {
-		printRow(truncate(r.predicateType, colWidth), truncateIdentity(r.identity, colWidth), truncate(r.subject, colWidth))
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(r.predicateType))
+		row.AddCell(termtable.WithContent(truncateIdentity(r.identity, budget)))
+		row.AddCell(termtable.WithContent(r.subject))
 	}
+	_, _ = t.WriteTo(w) //nolint:errcheck // writing to terminal
 }
 
-// printLsTableBySubject renders a two-column table (predicate type + identity)
-// preceded by a header showing the subjects being filtered. Each column gets
-// 50% of the terminal width.
+// printLsTableBySubject renders a two-column table (predicate type +
+// identity) preceded by a header showing the subjects being filtered.
 func printLsTableBySubject(w io.Writer, rows []lsRow, subjects []string) {
-	totalWidth := terminalWidth()
-	colWidth := (totalWidth - lsColumnGap) / 2
-
 	for _, s := range subjects {
 		fmt.Fprintf(w, "Subject: %s\n", s) //nolint:errcheck // writing to terminal
 	}
 	fmt.Fprintln(w) //nolint:errcheck // writing to terminal
 
-	printRow := func(a, b string) {
-		fmt.Fprintf(w, "%-*s%s\n", colWidth+lsColumnGap, a, b) //nolint:errcheck // writing to terminal
-	}
+	t := newLsTable()
+	equalColumnWidths(t, 2)
+	addLsHeader(t, lsHeaderPredicateType, lsHeaderSignerID)
 
-	printRow(lsHeaderPredicateType, lsHeaderSignerID)
-	printRow(strings.Repeat("-", colWidth), strings.Repeat("-", colWidth))
-
+	budget := identityBudget(t, 2)
 	for _, r := range rows {
-		printRow(truncate(r.predicateType, colWidth), truncateIdentity(r.identity, colWidth))
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(r.predicateType))
+		row.AddCell(termtable.WithContent(truncateIdentity(r.identity, budget)))
 	}
+	_, _ = t.WriteTo(w) //nolint:errcheck // writing to terminal
 }
 
 // printLsTableByType renders a two-column table (identity + subject)
-// preceded by a header showing the predicate types being filtered. Each
-// column gets 50% of the terminal width.
+// preceded by a header showing the predicate types being filtered.
 func printLsTableByType(w io.Writer, rows []lsRow, predicateTypes []string) {
-	totalWidth := terminalWidth()
-	colWidth := (totalWidth - lsColumnGap) / 2
-
 	for _, pt := range predicateTypes {
 		fmt.Fprintf(w, "Predicate type: %s\n", pt) //nolint:errcheck // writing to terminal
 	}
 	fmt.Fprintln(w) //nolint:errcheck // writing to terminal
 
-	printRow := func(a, b string) {
-		fmt.Fprintf(w, "%-*s%s\n", colWidth+lsColumnGap, a, b) //nolint:errcheck // writing to terminal
-	}
+	t := newLsTable()
+	equalColumnWidths(t, 2)
+	addLsHeader(t, lsHeaderSignerID, lsHeaderSubject)
 
-	printRow(lsHeaderSignerID, lsHeaderSubject)
-	printRow(strings.Repeat("-", colWidth), strings.Repeat("-", colWidth))
-
+	budget := identityBudget(t, 2)
 	for _, r := range rows {
-		printRow(truncateIdentity(r.identity, colWidth), truncate(r.subject, colWidth))
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(truncateIdentity(r.identity, budget)))
+		row.AddCell(termtable.WithContent(r.subject))
 	}
+	_, _ = t.WriteTo(w) //nolint:errcheck // writing to terminal
 }
 
 // printLsTableFiltered renders a single-column table of identities when both
 // subject and predicate type filters are active. The filters are printed above.
 func printLsTableFiltered(w io.Writer, rows []lsRow, subjects, predicateTypes []string) {
-	totalWidth := terminalWidth()
-
 	for _, pt := range predicateTypes {
 		fmt.Fprintf(w, "Predicate type: %s\n", pt) //nolint:errcheck // writing to terminal
 	}
@@ -424,24 +452,35 @@ func printLsTableFiltered(w io.Writer, rows []lsRow, subjects, predicateTypes []
 	}
 	fmt.Fprintln(w) //nolint:errcheck // writing to terminal
 
-	colWidth := totalWidth
-	fmt.Fprintln(w, lsHeaderSignerID)                           //nolint:errcheck // writing to terminal
-	fmt.Fprintln(w, strings.Repeat("-", len(lsHeaderSignerID))) //nolint:errcheck // writing to terminal
+	t := newLsTable()
+	t.Column(0).Style("white-space: nowrap; text-overflow: ellipsis")
+	addLsHeader(t, lsHeaderSignerID)
 
+	budget := identityBudget(t, 1)
 	for _, r := range rows {
-		fmt.Fprintln(w, truncateIdentity(r.identity, colWidth)) //nolint:errcheck // writing to terminal
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(truncateIdentity(r.identity, budget)))
 	}
+	_, _ = t.WriteTo(w) //nolint:errcheck // writing to terminal
 }
 
-// columnWidth returns the width of each column given the total terminal width.
-// Each of the three columns gets an equal share of the available space after
-// subtracting the inter-column gaps.
-func columnWidth(totalWidth int) int {
-	available := totalWidth - lsColumnGap*(lsNumColumns-1)
-	if available < lsNumColumns {
-		available = lsNumColumns
+// identityBudget estimates the content width allotted to the identity
+// column so truncateIdentity can preserve the "type::" prefix. termtable
+// handles overflow natively via text-overflow: ellipsis, but its default
+// truncation cuts the tail of the string, losing the prefix. Pre-trimming
+// keeps the prefix visible. Pass ncols as the number of columns the
+// table will end up with (the call sites know this statically).
+func identityBudget(t *termtable.Table, ncols int) int {
+	if ncols < 1 {
+		ncols = 1
 	}
-	return available / lsNumColumns
+	target := t.ResolvedTargetWidth()
+	// Overhead: seam per column gap + 2 chars of padding per column.
+	share := (target - ncols*3) / ncols
+	if share < 20 {
+		return 20
+	}
+	return share
 }
 
 // truncateIdentity shortens an identity string to maxLen. When truncation is

--- a/internal/cmd/ls_test.go
+++ b/internal/cmd/ls_test.go
@@ -32,23 +32,40 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-func TestColumnWidth(t *testing.T) {
+func TestTruncateIdentity(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name       string
-		totalWidth int
-		want       int
+		name     string
+		input    string
+		maxLen   int
+		expected []string // substrings the result must contain
 	}{
-		{"standard-80", 80, 24},
-		{"wide-120", 120, 38},
-		{"narrow-30", 30, 8},
-		{"very-narrow", 9, 1},
-		{"minimum-clamp", 2, 1},
+		{
+			"fits",
+			"sigstore::token.actions.githubusercontent.com::user@example.com",
+			200,
+			[]string{"sigstore::", "user@example.com"},
+		},
+		{
+			"keeps-prefix-on-truncate",
+			"sigstore::https://token.actions.githubusercontent.com::user@example.com",
+			30,
+			[]string{"sigstore::", "..."},
+		},
+		{
+			"no-prefix-keeps-tail",
+			"abcdefghij",
+			5,
+			[]string{"...ij"}, // no "::" prefix — ellipsis + tail
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := columnWidth(tt.totalWidth)
-			require.Equal(t, tt.want, got)
+			got := truncateIdentity(tt.input, tt.maxLen)
+			require.LessOrEqual(t, len(got), tt.maxLen)
+			for _, sub := range tt.expected {
+				require.Contains(t, got, sub)
+			}
 		})
 	}
 }
@@ -64,25 +81,25 @@ func TestPrintLsTable(t *testing.T) {
 	var buf bytes.Buffer
 	printLsTable(&buf, rows)
 	output := buf.String()
-
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-	require.GreaterOrEqual(t, len(lines), 5, "header + separator + 3 data rows")
 
-	// Header line
+	// Header row + header-underline rule + 3 data rows = 5 lines.
+	require.GreaterOrEqual(t, len(lines), 5, "header + rule + 3 data rows")
+
+	// Header line carries the uppercase titles.
 	require.Contains(t, lines[0], "PREDICATE TYPE")
 	require.Contains(t, lines[0], "SIGNER IDENTITY")
 	require.Contains(t, lines[0], "SUBJECT")
 
-	// Separator line
-	require.Contains(t, lines[1], "---")
+	// Second line is the header's bottom-border rule: dashes.
+	require.Contains(t, lines[1], "-")
 
-	// First data row has predicate type and subject
+	// First data row has predicate type and subject.
 	require.Contains(t, lines[2], "spdx.dev")
 	require.Contains(t, lines[2], "sha256:abc123")
 
-	// Third row (second identity for slsa) should not repeat predicate type
+	// Third row (second identity for slsa) should not repeat predicate type.
 	require.Contains(t, lines[4], "key::rsa::ABCD1234")
-	// The predicate column should be blank
 	idx := strings.Index(lines[4], "key::rsa")
 	require.GreaterOrEqual(t, idx, 0, "identity must be present in line")
 	predCol := strings.TrimRight(lines[4][:idx], " ")
@@ -96,5 +113,24 @@ func TestPrintLsTable_Empty(t *testing.T) {
 	output := buf.String()
 
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-	require.Len(t, lines, 2, "just header + separator for empty table")
+	// Header + rule line = 2 lines for an empty table.
+	require.Len(t, lines, 2, "header + rule for empty table")
+	require.Contains(t, lines[0], "PREDICATE TYPE")
+	require.Contains(t, lines[1], "-")
+}
+
+func TestPrintLsTableNoFramingGlyphs(t *testing.T) {
+	t.Parallel()
+	rows := []lsRow{
+		{"https://spdx.dev/Document", "sigstore::accounts.google.com::user@example.com", "sha256:abc123"},
+	}
+	var buf bytes.Buffer
+	printLsTable(&buf, rows)
+	output := buf.String()
+
+	// No box-drawing glyphs or ASCII frame characters — only the dash
+	// rule under the header.
+	for _, r := range "│┌┐└┘├┤┬┴┼+|═║╔╗╚╝╠╣╦╩╬" {
+		require.NotContains(t, output, string(r), "unexpected frame glyph %q", r)
+	}
 }


### PR DESCRIPTION
This pull request refactors the table rendering logic for the `ls` command, replacing manual formatting with the `termtable` library to improve maintainability and consistency. It introduces new helper functions for table setup and column sizing, removes custom column width calculations, and updates tests to match the new rendering approach.

**Table Rendering Refactor:**

- Replaces manual table formatting in `internal/cmd/ls.go` with the `termtable` library, introducing helper functions like `newLsTable`, `addLsHeader`, and `equalColumnWidths` to manage table appearance and layout. The new approach ensures consistent styling, borderless tables, and dynamic width allocation. [[1]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7R20-L21) [[2]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7L336-L418) [[3]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7L427-R483)
- Removes custom terminal width and column width calculations, delegating layout and truncation logic to `termtable` and new helper functions such as `identityBudget`. [[1]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7L32-L34) [[2]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7L336-L418) [[3]](diffhunk://#diff-0efa5cc71ffe63754d19e46c8313cefba775e7bc038bc95a07311ac3d962bbd7L427-R483)

**Dependency Updates:**

- Adds `github.com/carabiner-dev/termtable` and `github.com/rivo/uniseg` as dependencies in `go.mod` to support the new table rendering and Unicode handling. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R12-L18) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R126)
- Moves `golang.org/x/term` to an indirect dependency in `go.mod`, reflecting its removal from direct usage. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R12-L18) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R158)

**Testing Updates:**

- Updates and expands tests in `internal/cmd/ls_test.go` to verify the new table output, including checks for header formatting, absence of framing glyphs, and correct truncation behavior for identity strings. [[1]](diffhunk://#diff-8683484a1be422f202c84ac70efa952a152a2eb300980932ea446db4ceb43c74L35-R68) [[2]](diffhunk://#diff-8683484a1be422f202c84ac70efa952a152a2eb300980932ea446db4ceb43c74L67-L85) [[3]](diffhunk://#diff-8683484a1be422f202c84ac70efa952a152a2eb300980932ea446db4ceb43c74L99-R135)