### PR TITLE
Multi signer signer support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/jsonl v0.2.1
-	github.com/carabiner-dev/signer v0.4.5
+	github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be
 	github.com/carabiner-dev/termtable v1.1.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/in-toto/attestation v1.2.0
@@ -138,6 +138,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
 	github.com/transparency-dev/formats v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/jsonl v0.2.1
-	github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be
+	github.com/carabiner-dev/signer v0.4.6-0.20260428031626-298a979c4db9
 	github.com/carabiner-dev/termtable v1.1.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/in-toto/attestation v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/carabiner-dev/predicates v0.5.0 h1:CG2xO5xTXWXakjJkAFuS2xSA2olP9Ew25k
 github.com/carabiner-dev/predicates v0.5.0/go.mod h1:EUm2p0CwKoUuc+OLbGkoxLdRqBrg/r957b8iN/ACWSA=
 github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTurNaEZs=
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
-github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
-github.com/carabiner-dev/signer v0.4.5/go.mod h1:B/53ToJAIgwM+KuDwj52+HwnlA5p8Rmz2OXQdy9x+xs=
+github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be h1:YLd4fUHsnLv2vk6iDYSOQ1sHMS54PRmeoNEheQbaA2M=
+github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be/go.mod h1:cLqpW4oo9zFdDkelX5Cgx/6BQ5MEYSNlnXaE+Q7TFgY=
 github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
 github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.3 h1:rXKwVT8N4hS85GEJQGd0ZgOjTcALuCslsqZyg4g6qxA=
@@ -452,6 +452,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,10 @@ github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTur
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
 github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be h1:YLd4fUHsnLv2vk6iDYSOQ1sHMS54PRmeoNEheQbaA2M=
 github.com/carabiner-dev/signer v0.4.6-0.20260424233302-bfe05cc718be/go.mod h1:cLqpW4oo9zFdDkelX5Cgx/6BQ5MEYSNlnXaE+Q7TFgY=
+github.com/carabiner-dev/signer v0.4.6-0.20260428005800-b0053d7f372e h1:mwGUYbvYGJr9Ay0B2BvJ4rsGtaX0cgkm+cDRit6b6/4=
+github.com/carabiner-dev/signer v0.4.6-0.20260428005800-b0053d7f372e/go.mod h1:lQXabEgyFNLm49T3K3PKmU//H1+hEIOsF+13ZKgXhCs=
+github.com/carabiner-dev/signer v0.4.6-0.20260428031626-298a979c4db9 h1:J0CL4QiKoQ8bQWQtqFRFeBZt/E+pTKjPwSk7+Zwrj4Y=
+github.com/carabiner-dev/signer v0.4.6-0.20260428031626-298a979c4db9/go.mod h1:lQXabEgyFNLm49T3K3PKmU//H1+hEIOsF+13ZKgXhCs=
 github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
 github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.3 h1:rXKwVT8N4hS85GEJQGd0ZgOjTcALuCslsqZyg4g6qxA=

--- a/internal/cmd/commit.go
+++ b/internal/cmd/commit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/carabiner-dev/collector/predicate"
 	"github.com/carabiner-dev/collector/statement/intoto"
 	"github.com/carabiner-dev/signer"
-	"github.com/carabiner-dev/signer/options"
 	v1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -30,7 +29,7 @@ type commitOptions struct {
 	predicateFileOptions
 	signOptions
 	outFileOptions
-	options.Signer
+	signerSetOptions
 	CloneAddress     string
 	repoURL          string
 	repoPath         string
@@ -48,7 +47,7 @@ func (co *commitOptions) Validate() error {
 		co.signOptions.Validate(),
 		co.predicateFileOptions.Validate(),
 		co.outFileOptions.Validate(),
-		co.Signer.Validate(),
+		co.signerSetOptions.Validate(),
 	)
 
 	if co.Sha != "" && co.Tag != "" {
@@ -76,9 +75,7 @@ func (co *commitOptions) AddFlags(cmd *cobra.Command) {
 	co.predicateFileOptions.AddFlags(cmd)
 	co.outFileOptions.AddFlags(cmd)
 
-	co.FlagPrefix = sigstoreFlagPrefix
-	co.HideOIDCOptions = true
-	co.Signer.AddFlags(cmd)
+	co.signerSetOptions.AddFlags(cmd)
 
 	cmd.PersistentFlags().StringVar(
 		&co.Sha, "sha", "", "commit hash to attest (defaults to HEAD of main branch)",
@@ -99,8 +96,8 @@ func (co *commitOptions) AddFlags(cmd *cobra.Command) {
 
 func addCommit(parentCmd *cobra.Command) {
 	opts := &commitOptions{
-		Signer:      options.DefaultSigner,
-		remoteNames: []string{"upstream", "origin"},
+		signerSetOptions: defaultSignerSetOptions(),
+		remoteNames:      []string{"upstream", "origin"},
 	}
 	commitCmd := &cobra.Command{
 		Short: "attest git commits",
@@ -260,12 +257,19 @@ Same, but cloning the repo from a local clone:
 
 			logrus.Debugf("ATTESTATION:\n%s\n/ATTESTATION\n", string(attData))
 
-			sg := signer.NewSigner()
-			sg.Options = opts.Signer
-
-			bundle, err := sg.SignStatement(attData)
+			sg, err := signer.NewSignerFromSet(opts.SignerSet)
 			if err != nil {
-				return fmt.Errorf("writing signing statement: %w", err)
+				return fmt.Errorf("building signer: %w", err)
+			}
+			defer func() {
+				if err := sg.Close(); err != nil {
+					logrus.Warnf("closing signer credentials: %v", err)
+				}
+			}()
+
+			artifact, err := sg.SignStatement(attData)
+			if err != nil {
+				return fmt.Errorf("signing statement: %w", err)
 			}
 
 			o, closer, err := opts.OutputWriter()
@@ -274,8 +278,8 @@ Same, but cloning the repo from a local clone:
 			}
 			defer closer()
 
-			if err := sg.WriteBundle(bundle, o); err != nil {
-				return err
+			if _, err := artifact.WriteTo(o); err != nil {
+				return fmt.Errorf("writing artifact: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/ls.go
+++ b/internal/cmd/ls.go
@@ -260,7 +260,7 @@ func extractIdentities(r *render.Renderer, env attestation.Envelope, att attesta
 
 	var slugs []string
 	for _, id := range sigv.GetSignature().GetIdentities() {
-		s := id.Slug()
+		s := id.Principal()
 		if s != "" {
 			slugs = append(slugs, s)
 		}

--- a/internal/cmd/options_sign.go
+++ b/internal/cmd/options_sign.go
@@ -4,10 +4,9 @@
 package cmd
 
 import (
+	"github.com/carabiner-dev/signer/options"
 	"github.com/spf13/cobra"
 )
-
-const sigstoreFlagPrefix = "sigstore"
 
 type signOptions struct {
 	Sign bool
@@ -21,4 +20,24 @@ func (so *signOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&so.Sign, "sign", true, "trigger the signing process",
 	)
+}
+
+// signerSetOptions wraps the upstream options.SignerSet — the bundled
+// sign-side OptionsSet that registers --backend plus every per-backend
+// child set's flags (key, sigstore, spiffe). Use defaultSignerSetOptions
+// to construct.
+type signerSetOptions struct {
+	*options.SignerSet
+}
+
+// defaultSignerSetOptions builds a signerSetOptions defaulted to the
+// sigstore backend, matching the previous bnd default. The sigstore
+// child's OIDC flags are hidden to keep --help compact; users who
+// need to override OIDC details can still pass the hidden flags.
+func defaultSignerSetOptions() signerSetOptions {
+	set := options.DefaultSignerSet()
+	if set.Sigstore != nil && set.Sigstore.Sign != nil {
+		set.Sigstore.Sign.HideOIDCOptions = true
+	}
+	return signerSetOptions{SignerSet: set}
 }

--- a/internal/cmd/options_verify.go
+++ b/internal/cmd/options_verify.go
@@ -1,15 +1,36 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (
 	"errors"
 
+	"github.com/carabiner-dev/signer/options"
 	"github.com/spf13/cobra"
 )
 
-type verifcationOptions struct {
-	RequireCTlog        bool
-	RequireTimestamp    bool
-	RequireTlog         bool
+// verifierSetOptions wraps options.VerifierSet — the bundled
+// verify-side OptionsSet. It registers --key (raw public-key
+// verification), --sigstore-roots, and the --spiffe-* namespace; the
+// verifier dispatches to the right backend by inspecting the bundle's
+// leaf certificate (SPIFFE leaf carries a spiffe:// URI SAN). Callers
+// supply trust material for whichever backends they're willing to
+// accept; the inactive children contribute nothing at validate time.
+type verifierSetOptions struct {
+	*options.VerifierSet
+}
+
+func defaultVerifierSetOptions() verifierSetOptions {
+	return verifierSetOptions{VerifierSet: options.DefaultVerifierSet()}
+}
+
+// identityMatchOptions covers the sigstore-style certificate-identity
+// assertions that aren't part of the OptionsSet families. SPIFFE
+// identity constraints (trust domain, path) flow through
+// --spiffe-trust-domain / --spiffe-path / --spiffe-path-regex on the
+// VerifierSet, so they're not duplicated here.
+type identityMatchOptions struct {
 	SkipIdentityCheck   bool
 	ExpectedIssuer      string
 	ExpectedIssuerRegex string
@@ -17,55 +38,27 @@ type verifcationOptions struct {
 	ExpectedSanRegex    string
 }
 
-func (vo *verifcationOptions) AddFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVar(
-		&vo.RequireCTlog, "ctlog", true,
-		"require and check RFC 3161 timestamps in the verified bundle",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&vo.RequireTlog, "tlog", true,
-		"look for transparency log inclusion proof when verifying",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&vo.RequireTimestamp, "timestamps", true,
-		"look for observer timestamps when verifying",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&vo.SkipIdentityCheck, "skip-identity", false,
-		"allow skipping identity verification",
-	)
-
-	cmd.PersistentFlags().StringVar(
-		&vo.ExpectedSan, "identity", "",
-		"expected certificate identity (SAN)",
-	)
-
-	cmd.PersistentFlags().StringVar(
-		&vo.ExpectedSanRegex, "identity-regex", "",
-		"regex to check the certificate identity (SAN)",
-	)
-
-	cmd.PersistentFlags().StringVar(
-		&vo.ExpectedIssuer, "issuer", "",
-		"expected OIDC issuer for the certificate identity",
-	)
-
-	cmd.PersistentFlags().StringVar(
-		&vo.ExpectedIssuerRegex, "issuer-regex", "",
-		"regex to check the certificate's OIDC identity issuer",
-	)
+func (o *identityMatchOptions) AddFlags(cmd *cobra.Command) {
+	pf := cmd.PersistentFlags()
+	pf.BoolVar(&o.SkipIdentityCheck, "skip-identity", false,
+		"allow skipping identity verification")
+	pf.StringVar(&o.ExpectedSan, "identity", "",
+		"expected sigstore certificate identity (SAN)")
+	pf.StringVar(&o.ExpectedSanRegex, "identity-regex", "",
+		"regex to check the sigstore certificate identity (SAN)")
+	pf.StringVar(&o.ExpectedIssuer, "issuer", "",
+		"expected OIDC issuer for the certificate identity")
+	pf.StringVar(&o.ExpectedIssuerRegex, "issuer-regex", "",
+		"regex to check the certificate's OIDC identity issuer")
 }
 
-func (vo *verifcationOptions) Validate() error {
-	errs := []error{}
-	if vo.ExpectedIssuer != "" && vo.ExpectedIssuerRegex != "" {
-		errs = append(errs, errors.New("only one of issuer or issuer-regexp can be set at the same"))
+func (o *identityMatchOptions) Validate() error {
+	var errs []error
+	if o.ExpectedIssuer != "" && o.ExpectedIssuerRegex != "" {
+		errs = append(errs, errors.New("only one of --issuer or --issuer-regex can be set"))
 	}
-	if vo.ExpectedSan != "" && vo.ExpectedSanRegex != "" {
-		errs = append(errs, errors.New("only one of identity or identity-regexp can be set at the same"))
+	if o.ExpectedSan != "" && o.ExpectedSanRegex != "" {
+		errs = append(errs, errors.New("only one of --identity or --identity-regex can be set"))
 	}
 	return errors.Join(errs...)
 }

--- a/internal/cmd/predicate.go
+++ b/internal/cmd/predicate.go
@@ -16,7 +16,6 @@ import (
 	"github.com/carabiner-dev/collector/statement/intoto"
 	"github.com/carabiner-dev/hasher"
 	"github.com/carabiner-dev/signer"
-	"github.com/carabiner-dev/signer/options"
 	v1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,7 +25,7 @@ import (
 
 type predicateOptions struct {
 	signOptions
-	options.Signer
+	signerSetOptions
 	outFileOptions
 	predicateFileOptions
 	SubjectValues    []string
@@ -57,7 +56,7 @@ func (po *predicateOptions) Validate() error {
 	errs := append([]error{},
 		po.signOptions.Validate(),
 		po.predicateFileOptions.Validate(),
-		po.Signer.Validate(),
+		po.signerSetOptions.Validate(),
 		po.outFileOptions.Validate(),
 	)
 
@@ -78,9 +77,7 @@ func (po *predicateOptions) AddFlags(cmd *cobra.Command) {
 	po.predicateFileOptions.AddFlags(cmd)
 	po.outFileOptions.AddFlags(cmd)
 
-	po.FlagPrefix = sigstoreFlagPrefix
-	po.HideOIDCOptions = true
-	po.Signer.AddFlags(cmd)
+	po.signerSetOptions.AddFlags(cmd)
 
 	cmd.PersistentFlags().StringSliceVarP(
 		&po.SubjectValues, "subject", "s", []string{}, "list of hashes (algo:value) or paths to files to add as subjects ",
@@ -107,7 +104,7 @@ var (
 
 func addPredicate(parentCmd *cobra.Command) {
 	opts := &predicateOptions{
-		Signer: options.DefaultSigner,
+		signerSetOptions: defaultSignerSetOptions(),
 	}
 
 	attCmd := &cobra.Command{
@@ -223,12 +220,19 @@ func addPredicate(parentCmd *cobra.Command) {
 
 			logrus.Debugf("ATTESTATION:\n%s\n/ATTESTATION\n", string(attData))
 
-			signer := signer.NewSigner()
-			signer.Options = opts.Signer
-
-			bundle, err := signer.SignStatement(attData)
+			sg, err := signer.NewSignerFromSet(opts.SignerSet)
 			if err != nil {
-				return fmt.Errorf("writing signing statement: %w", err)
+				return fmt.Errorf("building signer: %w", err)
+			}
+			defer func() {
+				if err := sg.Close(); err != nil {
+					logrus.Warnf("closing signer credentials: %v", err)
+				}
+			}()
+
+			artifact, err := sg.SignStatement(attData)
+			if err != nil {
+				return fmt.Errorf("signing statement: %w", err)
 			}
 
 			o, closer, err := opts.OutputWriter()
@@ -237,8 +241,8 @@ func addPredicate(parentCmd *cobra.Command) {
 			}
 			defer closer()
 
-			if err := signer.WriteBundle(bundle, o); err != nil {
-				return err
+			if _, err := artifact.WriteTo(o); err != nil {
+				return fmt.Errorf("writing artifact: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/sign_test.go
+++ b/internal/cmd/sign_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 // TestSignerOptionsValidate verifies that the command options structs
-// initialized with DefaultSigner can parse the embedded sigstore roots and
-// pass signer validation. This ensures the signing commands can start the
-// sigstore flow without errors like "OIDC issuer URL missing" or
-// "signing config not set".
+// initialized with the default signer-set (sigstore backend) parse the
+// embedded sigstore roots and pass signer validation.
 func TestSignerOptionsValidate(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -25,58 +23,61 @@ func TestSignerOptionsValidate(t *testing.T) {
 		{
 			name: "statement",
 			validate: func() error {
-				opts := &statementOptions{Signer: options.DefaultSigner}
-				return opts.Signer.Validate()
+				opts := &statementOptions{signerSetOptions: defaultSignerSetOptions()}
+				return opts.signerSetOptions.Validate()
 			},
 		},
 		{
 			name: "predicate",
 			validate: func() error {
-				opts := &predicateOptions{Signer: options.DefaultSigner}
-				return opts.Signer.Validate()
+				opts := &predicateOptions{signerSetOptions: defaultSignerSetOptions()}
+				return opts.signerSetOptions.Validate()
 			},
 		},
 		{
 			name: "commit",
 			validate: func() error {
-				opts := &commitOptions{Signer: options.DefaultSigner}
-				return opts.Signer.Validate()
+				opts := &commitOptions{signerSetOptions: defaultSignerSetOptions()}
+				return opts.signerSetOptions.Validate()
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := tc.validate()
-			require.NoError(t, err)
+			require.NoError(t, tc.validate())
 		})
 	}
 }
 
-// TestSignerOptionsZeroValueFails verifies that a zero-valued Signer (without
-// DefaultSigner) fails validation, confirming commands must be initialized
-// with the default roots data.
+// TestSignerOptionsZeroValueFails verifies that a zero-valued
+// signerSetOptions (without the default constructor) fails validation,
+// confirming commands must be initialized via defaultSignerSetOptions().
 func TestSignerOptionsZeroValueFails(t *testing.T) {
 	t.Parallel()
-	opts := options.Signer{}
-	err := opts.Validate()
-	require.Error(t, err)
+	opts := signerSetOptions{}
+	require.Error(t, opts.Validate())
 }
 
-// TestSignerOptionsRootsPopulated verifies that after parsing roots, the
-// sigstore instance has the required signing configuration (OIDC issuer,
-// Fulcio URL, etc.) needed to start a signing flow.
-func TestSignerOptionsRootsPopulated(t *testing.T) {
+// TestSignerOptionsSigstoreBackendBuilds verifies that the default
+// signer set (no --signing-backend, no key/spiffe flags) auto-detects
+// sigstore and produces an *options.Signer with the instance config
+// needed to start a signing flow.
+func TestSignerOptionsSigstoreBackendBuilds(t *testing.T) {
 	t.Parallel()
-	signer := options.DefaultSigner
-	require.NoError(t, signer.ParseRoots())
+	opts := defaultSignerSetOptions()
+	require.Empty(t, opts.Backend, "Backend left empty so resolveBackend auto-detects")
 
-	require.NotEmpty(t, signer.OidcIssuerURL(), "OIDC issuer URL must be set after parsing roots")
-	require.NotEmpty(t, signer.FulcioURL(), "Fulcio URL must be set after parsing roots")
-	require.NotNil(t, signer.SigningConfig, "signing config must be set after parsing roots")
+	signerOpts, err := opts.BuildSigner()
+	require.NoError(t, err)
+	require.NotEmpty(t, signerOpts.OidcIssuerURL(), "OIDC issuer URL must be set after building signer options")
+	require.NotEmpty(t, signerOpts.FulcioURL(), "Fulcio URL must be set after building signer options")
+	require.NotNil(t, signerOpts.SigningConfig, "signing config must be set after building signer options")
 }
 
-// TestSignerCommandsRegisterFlags ensures the signing commands register their
-// flags without panicking and include the expected sigstore-prefixed flags.
+// TestSignerCommandsRegisterFlags ensures the signing commands register
+// flags from every backend (the bundled SignerSet exposes all of them
+// in --help, with --backend selecting which one Validate/BuildSigner
+// consults at runtime).
 func TestSignerCommandsRegisterFlags(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -86,21 +87,21 @@ func TestSignerCommandsRegisterFlags(t *testing.T) {
 		{
 			name: "statement",
 			addFlags: func(cmd *cobra.Command) {
-				opts := &statementOptions{Signer: options.DefaultSigner}
+				opts := &statementOptions{signerSetOptions: defaultSignerSetOptions()}
 				opts.AddFlags(cmd)
 			},
 		},
 		{
 			name: "predicate",
 			addFlags: func(cmd *cobra.Command) {
-				opts := &predicateOptions{Signer: options.DefaultSigner}
+				opts := &predicateOptions{signerSetOptions: defaultSignerSetOptions()}
 				opts.AddFlags(cmd)
 			},
 		},
 		{
 			name: "commit",
 			addFlags: func(cmd *cobra.Command) {
-				opts := &commitOptions{Signer: options.DefaultSigner}
+				opts := &commitOptions{signerSetOptions: defaultSignerSetOptions()}
 				opts.AddFlags(cmd)
 			},
 		},
@@ -111,13 +112,46 @@ func TestSignerCommandsRegisterFlags(t *testing.T) {
 			require.NotPanics(t, func() {
 				tc.addFlags(cmd)
 			})
-			// Verify the sigstore-prefixed OIDC flags are registered
-			f := cmd.PersistentFlags().Lookup("sigstore-oidc-client-id")
-			require.NotNil(t, f, "sigstore-oidc-client-id flag must be registered")
 
-			// Verify the sign flag is registered
-			f = cmd.PersistentFlags().Lookup("sign")
-			require.NotNil(t, f, "sign flag must be registered")
+			// The discriminator and at least one flag from each backend.
+			for _, flag := range []string{
+				"signing-backend",
+				"signing-key",           // KeysSign
+				"sigstore-roots",        // SigstoreCommon
+				"sigstore-instance",     // SigstoreSign
+				"sigstore-rekor-append", // SigstoreSign
+				"sigstore-timestamp",    // SigstoreSign
+				"sigstore-disable-sts",  // SigstoreSign
+				"spiffe-trust-domain",   // SpiffeCommon
+				"spiffe-socket",         // SpiffeSign
+			} {
+				require.NotNil(t, cmd.PersistentFlags().Lookup(flag), "flag %s must be registered", flag)
+			}
+
+			// OIDC flags are registered but hidden by defaultSignerSetOptions.
+			oidc := cmd.PersistentFlags().Lookup("sigstore-oidc-client-id")
+			require.NotNil(t, oidc, "sigstore-oidc-client-id must be registered")
+			require.True(t, oidc.Hidden, "sigstore-oidc-client-id should be hidden in --help")
+
+			require.NotNil(t, cmd.PersistentFlags().Lookup("sign"), "sign flag must be registered")
 		})
 	}
+}
+
+// TestSignerOptionsBackendSwitch verifies the --backend discriminator
+// drives BuildSigner: switching to BackendKey produces a Signer
+// configured for raw-key signing (no sigstore Instance plumbing).
+func TestSignerOptionsBackendSwitch(t *testing.T) {
+	t.Parallel()
+	opts := defaultSignerSetOptions()
+	opts.Backend = string(options.BackendKey)
+
+	// BackendKey requires at least one key path; this is a flag-time
+	// check, not a build-time check, so Validate passes.
+	require.NoError(t, opts.Validate())
+
+	// BuildSigner should fail because no signing key was supplied.
+	_, err := opts.BuildSigner()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no signing keys")
 }

--- a/internal/cmd/sign_test.go
+++ b/internal/cmd/sign_test.go
@@ -113,20 +113,26 @@ func TestSignerCommandsRegisterFlags(t *testing.T) {
 				tc.addFlags(cmd)
 			})
 
-			// The discriminator and at least one flag from each backend.
+			// The discriminators (--signing-backend, --signing-timestamp)
+			// plus at least one flag from each backend.
 			for _, flag := range []string{
 				"signing-backend",
+				"signing-timestamp",
 				"signing-key",           // KeysSign
 				"sigstore-roots",        // SigstoreCommon
 				"sigstore-instance",     // SigstoreSign
 				"sigstore-rekor-append", // SigstoreSign
-				"sigstore-timestamp",    // SigstoreSign
 				"sigstore-disable-sts",  // SigstoreSign
 				"spiffe-trust-domain",   // SpiffeCommon
 				"spiffe-socket",         // SpiffeSign
 			} {
 				require.NotNil(t, cmd.PersistentFlags().Lookup(flag), "flag %s must be registered", flag)
 			}
+
+			// --sigstore-timestamp is suppressed when bundled — the
+			// shared --signing-timestamp is the user-facing knob.
+			require.Nil(t, cmd.PersistentFlags().Lookup("sigstore-timestamp"),
+				"--sigstore-timestamp must NOT be registered when bundled via SignerSet")
 
 			// OIDC flags are registered but hidden by defaultSignerSetOptions.
 			oidc := cmd.PersistentFlags().Lookup("sigstore-oidc-client-id")

--- a/internal/cmd/statement.go
+++ b/internal/cmd/statement.go
@@ -10,13 +10,13 @@ import (
 	"os"
 
 	"github.com/carabiner-dev/signer"
-	"github.com/carabiner-dev/signer/options"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 type statementOptions struct {
 	signOptions
-	options.Signer
+	signerSetOptions
 	outFileOptions
 	StatementPath string
 }
@@ -26,7 +26,7 @@ func (so *statementOptions) Validate() error {
 	errs := append([]error{},
 		so.signOptions.Validate(),
 		so.outFileOptions.Validate(),
-		so.Signer.Validate(),
+		so.signerSetOptions.Validate(),
 	)
 
 	if so.StatementPath == "" {
@@ -36,9 +36,7 @@ func (so *statementOptions) Validate() error {
 }
 
 func (so *statementOptions) AddFlags(cmd *cobra.Command) {
-	so.FlagPrefix = sigstoreFlagPrefix
-	so.HideOIDCOptions = true
-	so.Signer.AddFlags(cmd)
+	so.signerSetOptions.AddFlags(cmd)
 
 	so.signOptions.AddFlags(cmd)
 	so.outFileOptions.AddFlags(cmd)
@@ -51,7 +49,7 @@ func (so *statementOptions) AddFlags(cmd *cobra.Command) {
 
 func addStatement(parentCmd *cobra.Command) {
 	opts := &statementOptions{
-		Signer: options.DefaultSigner,
+		signerSetOptions: defaultSignerSetOptions(),
 	}
 	attCmd := &cobra.Command{
 		Short:             "binds an in-toto attestation in a signed bundle",
@@ -85,12 +83,19 @@ func addStatement(parentCmd *cobra.Command) {
 				return fmt.Errorf("reading statement data: %w", err)
 			}
 
-			signer := signer.NewSigner()
-			signer.Options = opts.Signer
-
-			bundle, err := signer.SignStatement(attData)
+			sg, err := signer.NewSignerFromSet(opts.SignerSet)
 			if err != nil {
-				return fmt.Errorf("writing signing statement: %w", err)
+				return fmt.Errorf("building signer: %w", err)
+			}
+			defer func() {
+				if err := sg.Close(); err != nil {
+					logrus.Warnf("closing signer credentials: %v", err)
+				}
+			}()
+
+			artifact, err := sg.SignStatement(attData)
+			if err != nil {
+				return fmt.Errorf("signing statement: %w", err)
 			}
 
 			o, closer, err := opts.OutputWriter()
@@ -99,8 +104,8 @@ func addStatement(parentCmd *cobra.Command) {
 			}
 			defer closer()
 
-			if err := signer.WriteBundle(bundle, o); err != nil {
-				return err
+			if _, err := artifact.WriteTo(o); err != nil {
+				return fmt.Errorf("writing artifact: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -13,27 +13,32 @@ import (
 )
 
 type verifyOptions struct {
-	verifcationOptions
+	verifierSetOptions
+	identityMatchOptions
 	bundleOptions
 }
 
 // Validates the options in context with arguments
 func (o *verifyOptions) Validate() error {
 	return errors.Join(
-		o.verifcationOptions.Validate(),
+		o.verifierSetOptions.Validate(),
+		o.identityMatchOptions.Validate(),
 		o.bundleOptions.Validate(),
 	)
 }
 
 // AddFlags adds the flags to the subcommand
 func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
-	o.verifcationOptions.AddFlags(cmd)
+	o.verifierSetOptions.AddFlags(cmd)
+	o.identityMatchOptions.AddFlags(cmd)
 	o.bundleOptions.AddFlags(cmd)
 }
 
 // addVerify adds the verification command
 func addVerify(parentCmd *cobra.Command) {
-	opts := &verifyOptions{}
+	opts := &verifyOptions{
+		verifierSetOptions: defaultVerifierSetOptions(),
+	}
 	verifyCmd := &cobra.Command{
 		Short:             "Verifies a bundle signature",
 		Use:               "verify",
@@ -57,7 +62,10 @@ func addVerify(parentCmd *cobra.Command) {
 			// Silence usage here as options are validated
 			cmd.SilenceUsage = true
 
-			verifier := signer.NewVerifier()
+			verifier, err := signer.NewVerifierFromSet(opts.VerifierSet)
+			if err != nil {
+				return fmt.Errorf("building verifier: %w", err)
+			}
 
 			result, err := verifier.VerifyBundle(
 				opts.Path,
@@ -75,10 +83,17 @@ func addVerify(parentCmd *cobra.Command) {
 			}
 
 			fmt.Printf("\n✅ Bundle Verification OK!\n")
-			if !opts.SkipIdentityCheck {
+			if !opts.SkipIdentityCheck && result.VerifiedIdentity != nil {
 				fmt.Println("")
-				fmt.Printf("Signer:      %+s\n", result.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName)
-				fmt.Printf("OIDC Issuer: %+s\n", result.VerifiedIdentity.Issuer.Issuer)
+				san := result.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName
+				if san != "" {
+					fmt.Printf("Signer:      %s\n", san)
+				}
+				// SPIFFE bundles have no OIDC issuer; only print when
+				// we actually got one (sigstore path).
+				if issuer := result.VerifiedIdentity.Issuer.Issuer; issuer != "" {
+					fmt.Printf("OIDC Issuer: %s\n", issuer)
+				}
 			}
 			fmt.Println("")
 

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -63,7 +63,7 @@ func (r *Renderer) DisplayEnvelopeDetails(w io.Writer, envelope attestation.Enve
 							if i > 0 {
 								idstr += strings.Repeat(" ", 19)
 							}
-							idstr += id.Slug() + "\n"
+							idstr += id.Principal() + "\n"
 						}
 					}
 				}


### PR DESCRIPTION
This PR implements mulit-signer capabilities in the upcoming signer v0.5.  bnd now uses the the exported SignerSet options exported by the signer library. 

This means that bnd now can sign and verify attestations signed not just with sigstore but now can also sign with keys and SPIFFE SVIDs.