### PR TITLE
Render signer id, even when unverified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.0
 	github.com/in-toto/attestation v1.2.0
 	github.com/sigstore/protobuf-specs v0.5.1
+	github.com/sigstore/sigstore-go v1.1.4
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -133,7 +134,6 @@ require (
 	github.com/sigstore/rekor v1.5.1 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.2.1 // indirect
 	github.com/sigstore/sigstore v1.10.5 // indirect
-	github.com/sigstore/sigstore-go v1.1.4 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -4,6 +4,8 @@
 package render
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"strings"
@@ -11,6 +13,8 @@ import (
 	"github.com/carabiner-dev/attestation"
 	ampelb "github.com/carabiner-dev/collector/envelope/bundle"
 	signer "github.com/carabiner-dev/signer/api/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 
 	"github.com/carabiner-dev/bnd/pkg/bundle"
 )
@@ -29,6 +33,61 @@ func New(fn ...FnOpt) (*Renderer, error) {
 
 type Renderer struct {
 	Options Options
+}
+
+// unverifiedIdentityFromEnvelope reads the SAN/issuer straight from the bundle's
+// cert so inspect can still show who signed when trust-chain verification fails.
+func unverifiedIdentityFromEnvelope(envelope attestation.Envelope) (san, issuer string) {
+	bndl, ok := envelope.(*ampelb.Envelope)
+	if !ok {
+		return "", ""
+	}
+	vm := bndl.GetVerificationMaterial()
+	if vm == nil {
+		return "", ""
+	}
+	var cert *protocommon.X509Certificate
+	if c := vm.GetCertificate(); c != nil {
+		cert = c
+	} else if chain := vm.GetX509CertificateChain(); chain != nil && len(chain.GetCertificates()) > 0 {
+		cert = chain.GetCertificates()[0]
+	}
+	if cert == nil {
+		return "", ""
+	}
+	x509cert, err := parseDERorPEM(cert.GetRawBytes())
+	if err != nil {
+		return "", ""
+	}
+	summary, err := certificate.SummarizeCertificate(x509cert)
+	if err != nil {
+		return "", ""
+	}
+	return summary.SubjectAlternativeName, summary.Issuer
+}
+
+// parseDERorPEM accepts either DER (per the sigstore bundle spec) or PEM
+// (seen in some non-conformant bundles in the wild).
+func parseDERorPEM(raw []byte) (*x509.Certificate, error) {
+	if cert, err := x509.ParseCertificate(raw); err == nil {
+		return cert, nil
+	}
+	if block, _ := pem.Decode(raw); block != nil {
+		return x509.ParseCertificate(block.Bytes)
+	}
+	return nil, fmt.Errorf("unable to parse certificate as DER or PEM")
+}
+
+// shortVerifyError trims the wrapped error chain to its first line.
+func shortVerifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = msg[:i]
+	}
+	return strings.TrimSpace(msg)
 }
 
 // DisplayEnvelopeDetails prints the details of an attestation
@@ -51,7 +110,18 @@ func (r *Renderer) DisplayEnvelopeDetails(w io.Writer, envelope attestation.Enve
 	if r.Options.VerifySignatures {
 		verifyErr := envelope.Verify(r.Options.PublicKeys)
 		if verifyErr != nil {
-			idstr = fmt.Sprintf("[verification error: %s]\n", verifyErr)
+			san, issuer := unverifiedIdentityFromEnvelope(envelope)
+			switch {
+			case san != "" && issuer != "":
+				idstr = fmt.Sprintf("%s [⚠ unverified]\n%sIssuer: %s\n%s⚠ %s\n",
+					san, strings.Repeat(" ", 20), issuer,
+					strings.Repeat(" ", 20), shortVerifyError(verifyErr))
+			case san != "":
+				idstr = fmt.Sprintf("%s [⚠ unverified]\n%s⚠ %s\n",
+					san, strings.Repeat(" ", 20), shortVerifyError(verifyErr))
+			default:
+				idstr = fmt.Sprintf("[⚠ unverified: %s]\n", shortVerifyError(verifyErr))
+			}
 		}
 		if v := att.GetVerification(); v != nil {
 			idstr = "[No identity found]\n"


### PR DESCRIPTION
This pull request enhances the way the renderer displays signer information when signature verification fails, ensuring that the subject alternative name (SAN) and issuer are shown even if trust-chain verification cannot be completed. It introduces new helper functions for extracting and summarizing certificate information, and improves error reporting for failed verifications.

**Improvements to identity reporting and verification error handling:**

* Added `unverifiedIdentityFromEnvelope` and `parseDERorPEM` helper functions in `renderer.go` to extract the SAN and issuer directly from the signing certificate, even when verification fails. This ensures users can still see who signed an attestation in the presence of trust-chain issues.
* Updated the `DisplayEnvelopeDetails` method to use the new helper, displaying the SAN and issuer with a warning when verification fails, and trimming error messages to the first line for clarity.
* Added `shortVerifyError` helper to clean up error output for failed verifications.

**Dependency management:**

* Promoted `github.com/sigstore/sigstore-go` from an indirect to a direct dependency in `go.mod` to support new certificate parsing functionality. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R16) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L136)

**Imports and code organization:**

* Added necessary imports for certificate parsing and summarization in `renderer.go`.