### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.13

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -108,6 +108,13 @@ linters:
     - whitespace
     # - wsl
     - zerologlint
+
+  exclusions:
+    rules:
+      # Test data literals don't need to be hoisted into constants.
+      - path: _test\.go
+        linters:
+          - goconst
 
   settings:
     gocyclo:

--- a/internal/cmd/ls.go
+++ b/internal/cmd/ls.go
@@ -29,6 +29,8 @@ const (
 	lsHeaderPredicateType = "PREDICATE TYPE"
 	lsHeaderSignerID      = "SIGNER IDENTITY"
 	lsHeaderSubject       = "SUBJECT"
+
+	lsLabelUnsigned = "[unsigned]"
 )
 
 type lsOptions struct {
@@ -209,7 +211,7 @@ func buildLsRows(opts *lsOptions, verificationKeys []key.PublicKeyProvider, atts
 		}
 		identities := extractIdentities(renderer, env, att)
 		if len(identities) == 0 {
-			identities = []string{"[unsigned]"}
+			identities = []string{lsLabelUnsigned}
 		}
 
 		// First row carries predicate type, first identity and first subject.
@@ -246,7 +248,7 @@ func extractIdentities(r *render.Renderer, env attestation.Envelope, att attesta
 		if verifyErr != nil {
 			return []string{"[unverified]"}
 		}
-		return []string{"[unsigned]"}
+		return []string{lsLabelUnsigned}
 	}
 
 	if !v.GetVerified() {
@@ -255,7 +257,7 @@ func extractIdentities(r *render.Renderer, env attestation.Envelope, att attesta
 
 	sigv, ok := v.(*signer.Verification)
 	if !ok || sigv.GetSignature().GetIdentities() == nil {
-		return []string{"[unsigned]"}
+		return []string{lsLabelUnsigned}
 	}
 
 	var slugs []string
@@ -266,7 +268,7 @@ func extractIdentities(r *render.Renderer, env attestation.Envelope, att attesta
 		}
 	}
 	if len(slugs) == 0 {
-		return []string{"[unsigned]"}
+		return []string{lsLabelUnsigned}
 	}
 	return slugs
 }


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.11 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
